### PR TITLE
Removed possible ie fix. Causes javascript error on ie7.

### DIFF
--- a/audiojs/audio.js
+++ b/audiojs/audio.js
@@ -355,9 +355,7 @@
           audio.element.init(audio.mp3);
         }
         audio.playing = true;
-        // IE doesn't allow a method named `play()` to be exposed through `ExternalInterface`, so lets go with `pplay()`.  
-        // <http://dev.nuclearrooster.com/2008/07/27/externalinterfaceaddcallback-can-cause-ie-js-errors-with-certain-keyworkds/>
-        audio.element.pplay();
+        audio.element.play();
         audio.settings.play.apply(audio);
       }
       audio['pause'] = function() {


### PR DESCRIPTION
If you click on play with IE7 a javascript error occurs.
