### PR TITLE
Little fix when loading a song after a load error

### DIFF
--- a/audiojs/audio.js
+++ b/audiojs/audio.js
@@ -616,6 +616,9 @@
       this.element.load();
       this.mp3 = mp3;
       container[audiojs].events.trackLoadProgress(this);
+      // Remove the error because we load the next song
+      container[audiojs].helpers.removeClass(this.wrapper,
+                                             this.settings.createPlayer.errorClass);
     },
     loadError: function() {
       this.settings.loadError.apply(this);


### PR DESCRIPTION
When you have a playlist and one of the songs could not be played, if you skip(load) a new song from the playlist, the error will still be in the player even when this new song is playing correctly.

This patch remove the error class if the load function loads the song correctly.
