### PR TITLE
Small fix for settings.flashError

### DIFF
--- a/audiojs/audio.js
+++ b/audiojs/audio.js
@@ -244,7 +244,7 @@
         this.injectFlash(audio, id);
         this.attachFlashEvents(audio.wrapper, audio);
       } else if (s.useFlash && !s.hasFlash) {
-        this.settings.flashError.apply(audio);
+        s.flashError.apply(audio);
       }
 
       // Attach event callbacks to the new audiojs instance.


### PR DESCRIPTION
Currently default flashError handler is used in create(…) method (options one is ignored). This tiny fix should allow end-user to pass custom flashError handler (I had this use case).
