### PR TITLE
Return empty string when no path to audio.js found

### DIFF
--- a/audiojs/audio.js
+++ b/audiojs/audio.js
@@ -9,6 +9,8 @@
       var path = scripts[i].getAttribute('src');
       if(re.test(path)) return path.replace(re, '');
     }
+    // when no script found, an empty string causes the least confusion.
+    return '';
   })();
   
   // ##The audiojs interface


### PR DESCRIPTION
See my original report #110

This fixes the issue, in that the function no longer returns undefined but an empty string. This is actually fine for the Rails asset pipeline, since that is a flat directory structure.