### PR TITLE
Update audio.js

### DIFF
--- a/audiojs/audio.js
+++ b/audiojs/audio.js
@@ -639,6 +639,17 @@
         this.loadedPercent = durationLoaded / this.duration;
 
         this.settings.loadProgress.apply(this, [this.loadedPercent]);
+      }else
+      {
+    		  // audio duration in Android/Firefox
+    		  if (!this.loadStartedCalled) {
+    			  this.loadStartedCalled = this.loadStarted();
+    		  }
+
+      	  var durationLoaded = this.element.buffered.end(this.element.buffered.length - 1);
+          this.loadedPercent = durationLoaded / this.duration;
+
+          this.settings.loadProgress.apply(this, [this.loadedPercent]);
       }
     },
     playPause: function() {


### PR DESCRIPTION
Add an "else" in loadProgress: function() (line 642), due a problem in te progress bar and seek function in Firefox and Android.
I'm not the author, I had the problem and found the solution here: http://blog.svnlabs.com/html5-audio-duration-and-loadprogress-in-audio-js/#.U2mUZijijIc
