### PR TITLE
function path returns not the whole pathname

### DIFF
--- a/audiojs/audio.js
+++ b/audiojs/audio.js
@@ -7,7 +7,12 @@
         scripts = document.getElementsByTagName('script');
     for (var i = 0, ii = scripts.length; i < ii; i++) {
       var path = scripts[i].getAttribute('src');
-      if(re.test(path)) return path.replace(re, '');
+      if(re.test(path))
+      {
+        var f = path.split ( '/' );
+        f.pop ();
+        return f.join ( '/' ) + '/';
+      }
     }
   })();
   


### PR DESCRIPTION
the path function will not return the whole pathname if audio.js is a part of the path itself
for e.g.
if the script is loaded from http://example.com/js/audio.js/audio.js
it will returns only http://example.com/js/
instead of http://example.com/js/audio.js/

before the change - from line 10 :

<pre><code>      if(re.test(path) return path.replace(re, '');
</code></pre>

after the change - from line 10 till 15
<pre><code>     if(re.test(path))
      {
        var f = path.split ( '/' );
        f.pop ();
        return f.join ( '/' ) + '/';
      }
</code></pre>