### PR TITLE
Optimize repaints -> cpu usage

### DIFF
--- a/audiojs/audio.js
+++ b/audiojs/audio.js
@@ -178,7 +178,7 @@
       loadProgress: function(percent) {
         var player = this.settings.createPlayer,
             loaded = getByClass(player.loaderClass, this.wrapper);
-        loaded.style.width = (100 * percent) + '%';
+        loaded.style.width = Math.round(100 * percent) + '%';
       },
       playPause: function() {
         if (this.playing) this.settings.play();
@@ -196,7 +196,7 @@
       updatePlayhead: function(percent) {
         var player = this.settings.createPlayer,
             progress = getByClass(player.progressClass, this.wrapper);
-        progress.style.width = (100 * percent) + '%';
+        progress.style.width = Math.round(100 * percent) + '%';
 
         var played = getByClass(player.playedClass, this.wrapper),
             p = this.duration * percent,


### PR DESCRIPTION
When element get difference width's like 14.54477%, webkit repaint it (or calculate something) every time when value is updated, and my cpu usage become ~80%. When i use Math.round, i got normal cpu usage without any visual difference. Because webkit doesn't repaint an element, if previous css value is equivalent new. 
I think, in 95% situations `Math.round` is better, then terrible repainting and high cpu usage.